### PR TITLE
Returning the internal server so it can be used outside

### DIFF
--- a/server.go
+++ b/server.go
@@ -13,11 +13,12 @@ var (
 )
 
 // InitServer Initialize the service
-func InitServer(manager oauth2.Manager) {
+func InitServer(manager oauth2.Manager) *server.Server {
 	if err := manager.CheckInterface(); err != nil {
 		panic(err)
 	}
 	gServer = server.NewDefaultServer(manager)
+	return gServer
 }
 
 // HandleAuthorizeRequest the authorization request handling


### PR DESCRIPTION
My use case is that we have legacy auth that will be checked first then if that fails we will use the OAuth server.
So then I can't really use the HandleTokenVerify, so want to be able to use the `gserver.ValidationBearerToken` directly

Not sure if this is interesting at all. But for this helped me make the gin-server a bit more flexible.

Close it if it's not suited to be merged 👍 